### PR TITLE
transform method fatal error with trim function

### DIFF
--- a/src/Alpixel/Bundle/FormBundle/DataTransformer/EntityToIdTransformer.php
+++ b/src/Alpixel/Bundle/FormBundle/DataTransformer/EntityToIdTransformer.php
@@ -49,7 +49,7 @@ class EntityToIdTransformer implements DataTransformerInterface
 
     public function transform($data)
     {
-        if (null === $data || trim($data) === '') {
+        if (null === $data || (is_string($data) && trim($data) === '')) {
             return;
         }
 


### PR DESCRIPTION
Fixed the 'transform' method in 'EntityToIdTransformer' class, check if $data is a string to avoid a fatal error on the 'trim' function
